### PR TITLE
Exposed the getter and setter for incorrect attempts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ DerivedData
 # Sublime
 *.sublime-project
 *.sublime-workspace
+
+Carthage/Checkouts
+Carthage/Build

--- a/PasscodeLock.xcodeproj/project.pbxproj
+++ b/PasscodeLock.xcodeproj/project.pbxproj
@@ -449,12 +449,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Yanko Dimitrov";
 				TargetAttributes = {
 					C99EAF3E1B90B05700D61E1B = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1020;
 					};
 					C99EAF481B90B05700D61E1B = {
 						CreatedOnToolsVersion = 7.0;
@@ -463,7 +463,7 @@
 					C9D3DF0F1B91AD11008561EB = {
 						CreatedOnToolsVersion = 7.0;
 						DevelopmentTeam = 6HPG35RJ6Y;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					C9D3DF221B91AD11008561EB = {
@@ -480,7 +480,7 @@
 			};
 			buildConfigurationList = C99EAF391B90B05700D61E1B /* Build configuration list for PBXProject "PasscodeLock" */;
 			compatibilityVersion = "Xcode 9.3";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -676,6 +676,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -735,6 +736,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -805,6 +807,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -827,6 +830,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.yankodimitrov.PasscodeLock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -878,6 +882,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.yankodimitrov.PasscodeLockDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -897,6 +902,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.yankodimitrov.PasscodeLockDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/PasscodeLock.xcodeproj/xcshareddata/xcschemes/PasscodeLock.xcscheme
+++ b/PasscodeLock.xcodeproj/xcshareddata/xcschemes/PasscodeLock.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PasscodeLock/Functions.swift
+++ b/PasscodeLock/Functions.swift
@@ -17,9 +17,8 @@ func localizedStringFor(key: String, comment: String) -> String {
 }
 
 func bundleForResource(name: String, ofType type: String) -> Bundle {
-
-    if(Bundle.main.path(forResource: name, ofType: type) != nil) {
-        return Bundle.main
+    if Bundle.main.path(forResource: name, ofType: type) != nil {
+        return .main
     }
 
     return Bundle(for: PasscodeLock.self)

--- a/PasscodeLock/PasscodeLock/ConfirmPasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/ConfirmPasscodeState.swift
@@ -15,7 +15,7 @@ struct ConfirmPasscodeState: PasscodeLockStateType {
     let isCancellableAction = true
     var isTouchIDAllowed = false
     
-    fileprivate var passcodeToConfirm: String
+    private var passcodeToConfirm: String
     
     init(passcode: String) {
         

--- a/PasscodeLock/PasscodeLock/EnterPasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/EnterPasscodeState.swift
@@ -39,7 +39,7 @@ struct EnterPasscodeState: PasscodeLockStateType {
         }
     }
 
-    fileprivate mutating func postNotification() {
+    private mutating func postNotification() {
         guard !isNotificationSent else { return }
         NotificationCenter.default.post(name: PasscodeLockIncorrectPasscodeNotification, object: nil)
         isNotificationSent = true

--- a/PasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/PasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -11,7 +11,7 @@ import LocalAuthentication
 
 open class PasscodeLock: PasscodeLockType {
     open weak var delegate: PasscodeLockTypeDelegate?
-    open let configuration: PasscodeLockConfigurationType
+    public let configuration: PasscodeLockConfigurationType
 
     open var repository: PasscodeRepositoryType {
         return configuration.repository
@@ -25,8 +25,8 @@ open class PasscodeLock: PasscodeLockType {
         return isTouchIDEnabled() && configuration.isTouchIDAllowed && lockState.isTouchIDAllowed
     }
 
-    fileprivate var lockState: PasscodeLockStateType
-    fileprivate lazy var passcode = String()
+    private var lockState: PasscodeLockStateType
+    private lazy var passcode = String()
 
     public init(state: PasscodeLockStateType, configuration: PasscodeLockConfigurationType) {
         precondition(configuration.passcodeLength > 0, "Passcode length sould be greather than zero.")
@@ -71,14 +71,14 @@ open class PasscodeLock: PasscodeLockType {
         }
     }
 
-    fileprivate func handleTouchIDResult(_ success: Bool) {
+    private func handleTouchIDResult(_ success: Bool) {
         DispatchQueue.main.async { [weak self] in
             guard success, let strongSelf = self else { return }
             strongSelf.delegate?.passcodeLockDidSucceed(strongSelf)
         }
     }
 
-    fileprivate func isTouchIDEnabled() -> Bool {
+    private func isTouchIDEnabled() -> Bool {
         let context = LAContext()
         return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
     }

--- a/PasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/PasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -52,8 +52,11 @@ open class PasscodeLock: PasscodeLockType {
     }
 
     open func changeState(_ state: PasscodeLockStateType) {
-        lockState = state
-        delegate?.passcodeLockDidChangeState(self)
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.lockState = state
+            strongSelf.delegate?.passcodeLockDidChangeState(strongSelf)
+        }
     }
 
     open func authenticateWithTouchID() {

--- a/PasscodeLock/PasscodeLock/RemovePasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/RemovePasscodeState.swift
@@ -13,54 +13,33 @@ struct RemovePasscodeState: PasscodeLockStateType {
     let description: String
     let isCancellableAction = false
     var isTouchIDAllowed: Bool { return false }
-    
     private var isNotificationSent = false
-    
-    fileprivate var incorrectPasscodeAttemptsKey = "incorrectPasscodeAttemps"
-    private var incorrectPasscodeAttempts: Int {
-        get {
-            return UserDefaults.standard.integer(forKey: incorrectPasscodeAttemptsKey)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: incorrectPasscodeAttemptsKey)
-        }
-    }
-    
+
     init() {
-        
         title = localizedStringFor(key: "PasscodeLockEnterTitle", comment: "Enter passcode title")
         description = localizedStringFor(key: "PasscodeLockEnterDescription", comment: "Enter passcode description")
     }
-    
+
     mutating func accept(passcode: String, from lock: PasscodeLockType) {
         if lock.repository.check(passcode: passcode) {
-            
             lock.repository.delete()
-            
             lock.delegate?.passcodeLockDidSucceed(lock)
-            
-            incorrectPasscodeAttempts = 0
-            
+            lock.configuration.setIncorrectPasscodeAttempts(0)
         } else {
-            
-            incorrectPasscodeAttempts += 1
-            
-            if incorrectPasscodeAttempts >= lock.configuration.maximumInccorectPasscodeAttempts {
-                
+            let oldValue = lock.configuration.getIncorrectPasscodeAttempts()
+            lock.configuration.setIncorrectPasscodeAttempts(oldValue + 1)
+
+            if lock.configuration.getIncorrectPasscodeAttempts() >= lock.configuration.maximumIncorrectPasscodeAttempts {
                 postNotification()
             }
-            
+
             lock.delegate?.passcodeLockDidFail(lock)
         }
     }
-    
+
     fileprivate mutating func postNotification() {
-        
         guard !isNotificationSent else { return }
-        
         NotificationCenter.default.post(name: PasscodeLockIncorrectPasscodeNotification, object: nil)
-        
         isNotificationSent = true
     }
-
 }

--- a/PasscodeLock/PasscodeLock/RemovePasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/RemovePasscodeState.swift
@@ -37,7 +37,7 @@ struct RemovePasscodeState: PasscodeLockStateType {
         }
     }
 
-    fileprivate mutating func postNotification() {
+    private mutating func postNotification() {
         guard !isNotificationSent else { return }
         NotificationCenter.default.post(name: PasscodeLockIncorrectPasscodeNotification, object: nil)
         isNotificationSent = true

--- a/PasscodeLock/PasscodeLockPresenter.swift
+++ b/PasscodeLock/PasscodeLockPresenter.swift
@@ -10,13 +10,13 @@ import UIKit
 
 open class PasscodeLockPresenter {
     
-    fileprivate var mainWindow: UIWindow?
+    private var mainWindow: UIWindow?
     
-    fileprivate lazy var passcodeLockWindow = UIWindow(frame: UIScreen.main.bounds)
+    private lazy var passcodeLockWindow = UIWindow(frame: UIScreen.main.bounds)
         
-    fileprivate let passcodeConfiguration: PasscodeLockConfigurationType
+    private let passcodeConfiguration: PasscodeLockConfigurationType
     open var isPasscodePresented = false
-    open let passcodeLockVC: PasscodeLockViewController
+    public let passcodeLockVC: PasscodeLockViewController
     
     public init(mainWindow window: UIWindow?, configuration: PasscodeLockConfigurationType, viewController: PasscodeLockViewController) {
         
@@ -71,19 +71,16 @@ open class PasscodeLockPresenter {
     }
     
     internal func animatePasscodeLockDismissal() {
-        
         UIView.animate(
             withDuration: 0.5,
             delay: 0,
             usingSpringWithDamping: 1,
             initialSpringVelocity: 0,
-            options: UIViewAnimationOptions(),
+            options: [],
             animations: { [weak self] in
-                
                 self?.passcodeLockWindow.alpha = 0
             },
             completion: { [weak self] _ in
-                
                 self?.passcodeLockWindow.isHidden = true
                 self?.passcodeLockWindow.rootViewController = nil
                 self?.passcodeLockWindow.alpha = 1
@@ -91,7 +88,7 @@ open class PasscodeLockPresenter {
         )
     }
 
-    fileprivate func moveWindowsToFront() {
+    private func moveWindowsToFront() {
         let windowLevel = UIApplication.shared.windows.last?.windowLevel ?? UIWindowLevelNormal
         let maxWinLevel = max(windowLevel, UIWindowLevelNormal)
         passcodeLockWindow.windowLevel =  maxWinLevel + 1

--- a/PasscodeLock/PasscodeLockPresenter.swift
+++ b/PasscodeLock/PasscodeLockPresenter.swift
@@ -12,8 +12,12 @@ open class PasscodeLockPresenter {
     
     private var mainWindow: UIWindow?
     
-    private lazy var passcodeLockWindow = UIWindow(frame: UIScreen.main.bounds)
-        
+    private lazy var passcodeLockWindow: UIWindow = {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.accessibilityLabel = "PasscodeLock Window"
+        return window
+    }()
+
     private let passcodeConfiguration: PasscodeLockConfigurationType
     open var isPasscodePresented = false
     public let passcodeLockVC: PasscodeLockViewController

--- a/PasscodeLock/PasscodeLockPresenter.swift
+++ b/PasscodeLock/PasscodeLockPresenter.swift
@@ -89,8 +89,8 @@ open class PasscodeLockPresenter {
     }
 
     private func moveWindowsToFront() {
-        let windowLevel = UIApplication.shared.windows.last?.windowLevel ?? UIWindowLevelNormal
-        let maxWinLevel = max(windowLevel, UIWindowLevelNormal)
+        let windowLevel = UIApplication.shared.windows.last?.windowLevel ?? UIWindow.Level.normal
+        let maxWinLevel = max(windowLevel, .normal)
         passcodeLockWindow.windowLevel =  maxWinLevel + 1
     }
 }

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -105,13 +105,13 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
     // MARK: - Events
 
     private func setupEvents() {
-        notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appWillEnterForegroundHandler(_:)), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
-        notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appDidEnterBackgroundHandler(_:)), name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
+        notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appWillEnterForegroundHandler(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
+        notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appDidEnterBackgroundHandler(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     private func clearEvents() {
-        notificationCenter?.removeObserver(self, name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
-        notificationCenter?.removeObserver(self, name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
+        notificationCenter?.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+        notificationCenter?.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
     @objc open func appWillEnterForegroundHandler(_ notification: Notification) {

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -58,7 +58,7 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
         passcodeConfiguration = configuration
         passcodeLock = PasscodeLock(state: state, configuration: configuration)
 
-        let this = PasscodeLockViewController.self
+        let this = type(of: self)
         super.init(nibName: this.nibName, bundle: this.nibBundle)
 
         passcodeLock.delegate = self

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -25,6 +25,12 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
         }
     }
 
+    private static var nibName: String { return "PasscodeLockView" }
+
+    open class var nibBundle: Bundle {
+        return bundleForResource(name: nibName, ofType: "nib")
+    }
+
     @IBOutlet open var placeholders: [PasscodeSignPlaceholderView] = [PasscodeSignPlaceholderView]()
     @IBOutlet open weak var titleLabel: UILabel?
     @IBOutlet open weak var descriptionLabel: UILabel?
@@ -52,10 +58,8 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
         passcodeConfiguration = configuration
         passcodeLock = PasscodeLock(state: state, configuration: configuration)
 
-        let nibName = "PasscodeLockView"
-        let bundle: Bundle = bundleForResource(name: nibName, ofType: "nib")
-
-        super.init(nibName: nibName, bundle: bundle)
+        let this = PasscodeLockViewController.self
+        super.init(nibName: this.nibName, bundle: this.nibBundle)
 
         passcodeLock.delegate = self
         notificationCenter = NotificationCenter.default

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -42,7 +42,7 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
     internal var passcodeLock: PasscodeLockType
     internal var isPlaceholdersAnimationCompleted = true
 
-    fileprivate var shouldTryToAuthenticateWithBiometrics = true
+    private var shouldTryToAuthenticateWithBiometrics = true
 
     // MARK: - Initializers
 
@@ -104,12 +104,12 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
 
     // MARK: - Events
 
-    fileprivate func setupEvents() {
+    private func setupEvents() {
         notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appWillEnterForegroundHandler(_:)), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
         notificationCenter?.addObserver(self, selector: #selector(PasscodeLockViewController.appDidEnterBackgroundHandler(_:)), name: Notification.Name.UIApplicationDidEnterBackground, object: nil)
     }
 
-    fileprivate func clearEvents() {
+    private func clearEvents() {
         notificationCenter?.removeObserver(self, name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         notificationCenter?.removeObserver(self, name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
     }
@@ -142,7 +142,7 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
         passcodeLock.authenticateWithTouchID()
     }
 
-    fileprivate func authenticateWithTouchID() {
+    private func authenticateWithTouchID() {
         if passcodeConfiguration.shouldRequestTouchIDImmediately && passcodeLock.isTouchIDAllowed {
             passcodeLock.authenticateWithTouchID()
         }
@@ -195,7 +195,7 @@ open class PasscodeLockViewController: UIViewController, PasscodeLockTypeDelegat
         placeholders.forEach { $0.animateState(state) }
     }
 
-    fileprivate func animatePlacehodlerAtIndex(_ index: Int, toState state: PasscodeSignPlaceholderView.State) {
+    private func animatePlacehodlerAtIndex(_ index: Int, toState state: PasscodeSignPlaceholderView.State) {
         guard index < placeholders.count && index >= 0 else { return }
 
         placeholders[index].animateState(state)

--- a/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
+++ b/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
@@ -9,10 +9,22 @@
 import Foundation
 
 public protocol PasscodeLockConfigurationType {
-    
     var repository: PasscodeRepositoryType { get }
     var passcodeLength: Int { get }
     var isTouchIDAllowed: Bool { get set }
     var shouldRequestTouchIDImmediately: Bool { get }
-    var maximumInccorectPasscodeAttempts: Int { get }
+    var maximumIncorrectPasscodeAttempts: Int { get }
+    func getIncorrectPasscodeAttempts() -> Int
+    func setIncorrectPasscodeAttempts(_ value: Int)
+}
+
+fileprivate let incorrectPasscodeAttemptsKey = "incorrectPasscodeAttempts"
+extension PasscodeLockConfigurationType {
+    public func getIncorrectPasscodeAttempts() -> Int {
+        return UserDefaults.standard.integer(forKey: incorrectPasscodeAttemptsKey)
+    }
+
+    public func setIncorrectPasscodeAttempts(_ value: Int) {
+        UserDefaults.standard.set(value, forKey: incorrectPasscodeAttemptsKey)
+    }
 }

--- a/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
+++ b/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
@@ -18,7 +18,8 @@ public protocol PasscodeLockConfigurationType {
     func setIncorrectPasscodeAttempts(_ value: Int)
 }
 
-fileprivate let incorrectPasscodeAttemptsKey = "incorrectPasscodeAttempts"
+private let incorrectPasscodeAttemptsKey = "incorrectPasscodeAttempts"
+
 extension PasscodeLockConfigurationType {
     public func getIncorrectPasscodeAttempts() -> Int {
         return UserDefaults.standard.integer(forKey: incorrectPasscodeAttemptsKey)

--- a/PasscodeLock/Views/PasscodeSignButton.swift
+++ b/PasscodeLock/Views/PasscodeSignButton.swift
@@ -51,9 +51,9 @@ open class PasscodeSignButton: UIButton {
         return CGSize(width: 60, height: 60)
     }
 
-    fileprivate var defaultBackgroundColor: UIColor = .clear
+    private var defaultBackgroundColor: UIColor = .clear
 
-    fileprivate func setupView() {
+    private func setupView() {
         layer.borderWidth = 1
         layer.cornerRadius = borderRadius
         layer.borderColor = borderColor.cgColor
@@ -63,7 +63,7 @@ open class PasscodeSignButton: UIButton {
         }
     }
 
-    fileprivate func setupActions() {
+    private func setupActions() {
         addTarget(self, action: #selector(PasscodeSignButton.handleTouchDown), for: .touchDown)
         addTarget(self, action: #selector(PasscodeSignButton.handleTouchUp), for: [.touchUpInside, .touchDragOutside, .touchCancel])
     }
@@ -76,7 +76,7 @@ open class PasscodeSignButton: UIButton {
         animateBackgroundColor(defaultBackgroundColor)
     }
 
-    fileprivate func animateBackgroundColor(_ color: UIColor) {
+    private func animateBackgroundColor(_ color: UIColor) {
         UIView.animate(
             withDuration: 0.3,
             delay: 0.0,

--- a/PasscodeLock/Views/PasscodeSignPlaceholderView.swift
+++ b/PasscodeLock/Views/PasscodeSignPlaceholderView.swift
@@ -62,7 +62,7 @@ open class PasscodeSignPlaceholderView: UIView {
         return CGSize(width: 16, height: 16)
     }
     
-    fileprivate func setupView() {
+    private func setupView() {
         
         layer.cornerRadius = cornerRadius
         layer.borderWidth = 1
@@ -70,7 +70,7 @@ open class PasscodeSignPlaceholderView: UIView {
         backgroundColor = inactiveColor
     }
     
-    fileprivate func colorsForState(_ state: State) -> (backgroundColor: UIColor, borderColor: UIColor) {
+    private func colorsForState(_ state: State) -> (backgroundColor: UIColor, borderColor: UIColor) {
         
         switch state {
         case .inactive: return (inactiveColor, activeColor)

--- a/PasscodeLockDemo/AppDelegate.swift
+++ b/PasscodeLockDemo/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return presenter
     }()
     
-    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         
         passcodeLockPresenter.present()
         

--- a/PasscodeLockDemo/PasscodeLockConfiguration.swift
+++ b/PasscodeLockDemo/PasscodeLockConfiguration.swift
@@ -10,20 +10,17 @@ import Foundation
 import PasscodeLock
 
 struct PasscodeLockConfiguration: PasscodeLockConfigurationType {
-    
     let repository: PasscodeRepositoryType
     let passcodeLength = 6
     var isTouchIDAllowed = true
     let shouldRequestTouchIDImmediately = true
-    let maximumInccorectPasscodeAttempts = -1
-    
+    let maximumIncorrectPasscodeAttempts = -1
+
     init(repository: PasscodeRepositoryType) {
-        
         self.repository = repository
     }
-    
+
     init() {
-        
         self.repository = UserDefaultsPasscodeRepository()
     }
 }

--- a/PasscodeLockDemo/UserDefaultsPasscodeRepository.swift
+++ b/PasscodeLockDemo/UserDefaultsPasscodeRepository.swift
@@ -14,39 +14,34 @@ public enum PasscodeError: Error {
 }
 
 class UserDefaultsPasscodeRepository: PasscodeRepositoryType {
-    
     private let passcodeKey = "passcode.lock.passcode"
-    
+
     private lazy var defaults: UserDefaults = {
-        return UserDefaults.standard
+        UserDefaults.standard
     }()
-    
+
     var hasPasscode: Bool {
-        
         if passcode != nil {
             return true
         }
-        
+
         return false
     }
-    
+
     private var passcode: String? {
-        
         return defaults.value(forKey: passcodeKey) as? String ?? nil
     }
-    
+
     func save(passcode: String) {
-        
         defaults.set(passcode, forKey: passcodeKey)
         defaults.synchronize()
     }
-    
+
     func check(passcode: String) -> Bool {
         return self.passcode == passcode
     }
-    
+
     func delete() {
-        
         defaults.removeObject(forKey: passcodeKey)
         defaults.synchronize()
     }

--- a/PasscodeLockTests/Fakes/FakePasscodeLockConfiguration.swift
+++ b/PasscodeLockTests/Fakes/FakePasscodeLockConfiguration.swift
@@ -9,15 +9,13 @@
 import Foundation
 
 class FakePasscodeLockConfiguration: PasscodeLockConfigurationType {
-    
     let repository: PasscodeRepositoryType
     let passcodeLength = 4
     var isTouchIDAllowed = false
-    let maximumInccorectPasscodeAttempts = 3
+    let maximumIncorrectPasscodeAttempts = 3
     let shouldRequestTouchIDImmediately = false
-    
+
     init(repository: PasscodeRepositoryType) {
-        
         self.repository = repository
     }
 }


### PR DESCRIPTION
# Changelog
- Exposed getter and setter for `incorrectPasscodeAttempts` with default protocol implementation. This way the client of this library can use keychain to store this to make it temper proof. This preserves the existing behavior and just exposes override to let the users specify their own hooks for storage.
- Fixed typos
- Linting